### PR TITLE
Rework of the algorithm that determines the voxel type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ inputfile/*
 .DS_store
 *.dSYM/Contents/Info.plist
 benchmark
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inputfile/*
 !inputfile/radii.txt
 .DS_store
 *.dSYM/Contents/Info.plist
+benchmark

--- a/atom.h
+++ b/atom.h
@@ -2,6 +2,7 @@
 
 #define ATOM_H
 
+#include "exception.h"
 #include <array>
 #include <iostream>
 
@@ -23,6 +24,14 @@ struct Atom{
 
   const std::array<double,3> getPos() const {
     return {pos_x, pos_y, pos_z};
+  }
+  const double getCoordinate(const char& dim){
+    switch(dim){
+      case 0: return pos_x;
+      case 1: return pos_y;
+      case 2: return pos_z;
+    }
+    throw ExceptIllegalFunctionCall();
   }
 };
 

--- a/atom.h
+++ b/atom.h
@@ -25,6 +25,11 @@ struct Atom{
   const std::array<double,3> getPos() const {
     return {pos_x, pos_y, pos_z};
   }
+  
+  const double getRad() const {
+    return rad;
+  }
+  
   const double getCoordinate(const char& dim){
     switch(dim){
       case 0: return pos_x;
@@ -32,6 +37,10 @@ struct Atom{
       case 2: return pos_z;
     }
     throw ExceptIllegalFunctionCall();
+  }
+  void print(){
+    printf("Object: Atom {%s, (%1.3f, %1.3f, %1.3f)}", symbol.c_str(), pos_x, pos_y, pos_z);
+    return; 
   }
 };
 
@@ -52,5 +61,7 @@ static inline unsigned int symbolToNumber(const std::string& symbol){
   std::cout << "There has been an error in atom.h" << std::endl;
   return 0;
 }
-  
+
+
+
 #endif

--- a/atom.h
+++ b/atom.h
@@ -19,18 +19,20 @@ struct Atom{
   double pos_x, pos_y, pos_z, rad;
   unsigned int number;
   std::string symbol;
+  //std::vector<Atom*> close_atoms;
 
-  std::array<double,3> getPos(){
+  const std::array<double,3> getPos() const {
     return {pos_x, pos_y, pos_z};
   }
 };
 
 
 static inline unsigned int symbolToNumber(const std::string& symbol){
-  const std::array<std::string,18> element_symbols = {
+  const std::array<std::string,30> element_symbols = {
     "H" , "He",
     "Li", "Be", "B" , "C" , "N" , "O" , "F" , "Ne",
-    "Na", "Mg", "Al", "Si", "P" , "S" , "Cl", "Ar"
+    "Na", "Mg", "Al", "Si", "P" , "S" , "Cl", "Ar",
+    "K" , "Ca", "Sc", "Ti", "V" , "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn"
   };
 
   for(int i = 0; i < element_symbols.size(); i++){

--- a/atomtree.cpp
+++ b/atomtree.cpp
@@ -2,6 +2,12 @@
 #include "atomtree.h"
 #include "atom.h"
 
+///////////////////
+// AUX FUNCTIONS //
+///////////////////
+
+double findMaxRad(std::vector<Atom>& list_of_atoms);
+
 //////////////
 // ATOMNODE //
 //////////////
@@ -38,10 +44,26 @@ void AtomNode::print(){
 
 AtomTree::AtomTree(){
   root = NULL;
+  max_rad = 0;
 }
 
 AtomTree::AtomTree(std::vector<Atom>& list_of_atoms){
-  root = buildTree(list_of_atoms, 0, list_of_atoms.size(), 0);
+  root = buildTree(list_of_atoms, 0, list_of_atoms.size(), 0); 
+  // ideally, the maximum radius would be the largest radius among all children of a node.
+  // this, however, may require running an algorithm for every tree node, increasing the
+  // complexity of the operation. it is much simpler to use the maximum radius among all
+  // atoms instead, sacrificing optimisation.
+  max_rad = findMaxRad(list_of_atoms);
+}
+
+double findMaxRad(std::vector<Atom>& list_of_atoms){
+  double max_rad = 0;
+  for (int atom = 0; atom < list_of_atoms.size(); atom++){
+    if (list_of_atoms[atom].getRad() > max_rad){
+      max_rad = list_of_atoms[atom].getRad();
+    }
+  }
+  return max_rad;
 }
 
     // recursive function to generate a 3-d tree from a list of atoms
@@ -66,7 +88,7 @@ AtomNode* AtomTree::buildTree(
     quicksort(list_of_atoms, vec_first, vec_end, dim);
     int median = vec_first + (vec_end-vec_first)/2; // operation rounds down
     return new AtomNode(
-        &list_of_atoms[median], 
+       &list_of_atoms[median], 
         buildTree(list_of_atoms, vec_first, median, (dim+1)%3), 
         buildTree(list_of_atoms, median+1, vec_end, (dim+1)%3)); 
   }
@@ -111,4 +133,16 @@ void AtomTree::swap(Atom& a, Atom& b){
   a = b;
   b = temp;
   return;
+}
+
+////////////
+// ACCESS //
+////////////
+
+const double AtomTree::getMaxRad() const {
+  return max_rad;
+}
+
+const AtomNode* AtomTree::getRoot() const {
+  return root;
 }

--- a/atomtree.cpp
+++ b/atomtree.cpp
@@ -11,7 +11,10 @@ AtomNode::AtomNode(Atom* at, AtomNode* left_node, AtomNode* right_node)
 
 void AtomNode::print(){
   if(atom!=NULL){
-    std::cout << atom->symbol;
+    std::cout << atom->symbol << "(" 
+      << atom->getCoordinate(0) << "," 
+      << atom->getCoordinate(1) << "," 
+      << atom->getCoordinate(2) << ")";
   }
   else{
     std::cout << "n/A";
@@ -60,16 +63,16 @@ AtomNode* AtomTree::buildTree(
   }
 
   else{
-    sort(list_of_atoms, vec_first, vec_end, dim);
-    int median = (vec_end-vec_first)/2; // operation rounds down
+    quicksort(list_of_atoms, vec_first, vec_end, dim);
+    int median = vec_first + (vec_end-vec_first)/2; // operation rounds down
     return new AtomNode(
         &list_of_atoms[median], 
-        buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
-        buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
+        buildTree(list_of_atoms, vec_first, median, (dim+1)%3), 
+        buildTree(list_of_atoms, median+1, vec_end, (dim+1)%3)); 
   }
 }
 
-void AtomTree::print(){
+void AtomTree::print() const {
   std::cout << "Printing Tree" << std::endl;
   if(root == NULL){
     std::cout << "Tree empty" << std::endl;
@@ -81,8 +84,31 @@ void AtomTree::print(){
   return;
 }
     
-void AtomTree::sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
-  // TODO  
+void AtomTree::quicksort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
+  
+  if(vec_first >= vec_end-1){
+    return;
+  }
+    
+  double pivot = list_of_atoms[vec_end-1].getCoordinate(dim);
+  
+  int cntr = vec_first;
+
+  for(int i = vec_first; i < vec_end; i++){
+    if(list_of_atoms[i].getCoordinate(dim) <= pivot){
+      swap(list_of_atoms[cntr], list_of_atoms[i]);
+      cntr++;
+    }
+  }
+  quicksort(list_of_atoms, vec_first, cntr-1, dim);
+  quicksort(list_of_atoms, cntr, vec_end, dim);
+
   return;
 }
 
+void AtomTree::swap(Atom& a, Atom& b){
+  Atom temp = a;
+  a = b;
+  b = temp;
+  return;
+}

--- a/atomtree.cpp
+++ b/atomtree.cpp
@@ -1,0 +1,88 @@
+
+#include "atomtree.h"
+#include "atom.h"
+
+//////////////
+// ATOMNODE //
+//////////////
+
+AtomNode::AtomNode(Atom* at, AtomNode* left_node, AtomNode* right_node) 
+    : atom(at), left_child(left_node), right_child(right_node) {}
+
+void AtomNode::print(){
+  if(atom!=NULL){
+    std::cout << atom->symbol;
+  }
+  else{
+    std::cout << "n/A";
+  }
+
+  std::cout << "(-";
+  if(left_child!=NULL){
+    left_child->print();
+  }
+  std::cout << " +";
+  if(right_child!=NULL){
+    right_child->print();
+  }
+  std::cout << ")";
+  return;
+}
+
+//////////////
+// ATOMTREE //
+//////////////
+
+AtomTree::AtomTree(){
+  root = NULL;
+}
+
+AtomTree::AtomTree(std::vector<Atom>& list_of_atoms){
+  root = buildTree(list_of_atoms, 0, list_of_atoms.size(), 0);
+}
+
+    // recursive function to generate a 3-d tree from a list of atoms
+    // rather than copying the list of atoms in every recursion, or saving the partitioned
+    // vectors, the original list of atoms is passed by reference and only the vector limits
+    // are passed by value. any sorting during the tree building occurs in the original list
+AtomNode* AtomTree::buildTree(
+    std::vector<Atom>& list_of_atoms, 
+    int vec_first, // index of first vector element (default 0)
+    int vec_end, // vector size (index of last element + 1)
+    char dim){
+  // if list of atoms has no atoms left
+  if((vec_end-vec_first)==0){
+    return NULL;
+  }
+  // if list of atoms has exactly one atom left
+  else if((vec_end-vec_first)==1){
+    return new AtomNode(&list_of_atoms[vec_first],NULL,NULL);
+  }
+
+  else{
+    sort(list_of_atoms, vec_first, vec_end, dim);
+    int median = (vec_end-vec_first)/2; // operation rounds down
+    return new AtomNode(
+        &list_of_atoms[median], 
+        buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
+        buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
+  }
+}
+
+void AtomTree::print(){
+  std::cout << "Printing Tree" << std::endl;
+  if(root == NULL){
+    std::cout << "Tree empty" << std::endl;
+  }
+  else{
+    root->print();
+  }
+  std::cout << std::endl;
+  return;
+}
+    
+void AtomTree::sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
+  // TODO  
+  return;
+}
+

--- a/atomtree.h
+++ b/atomtree.h
@@ -6,18 +6,19 @@
 #include <vector>
 #include <cmath> 
 
+struct Atom;
 class AtomTree{
   public:
-    AtomTree(Atom* at, AtomTree left_node, AtomTree right_node) 
+    AtomTree(Atom* at, AtomTree* left_node, AtomTree* right_node) 
       : atom(at), left_child(left_node), right_child(right_node) {}
     
     Atom* atom = NULL;
     
     //TODO add exception for empty node
-    AtomTree getLeftChild(){
+    AtomTree* getLeftChild(){
       return left_child;
     }
-    AtomTree getRightChild(){
+    AtomTree* getRightChild(){
       return right_child;
     }
     
@@ -25,7 +26,7 @@ class AtomTree{
     // rather than copying the list of atoms in every recursion, or saving the partitioned
     // vectors, the original list of atoms is passed by reference and only the vector limits
     // are passed by value. any sorting during the tree building occurs in the original list
-    AtomTree buildTree(
+    AtomTree* buildTree(
         std::vector<Atom>& list_of_atoms, 
         int vec_first, // index of first vector element (default 0)
         int vec_end, // vector size (index of last element + 1)
@@ -36,21 +37,21 @@ class AtomTree{
       }
       // if list of atoms has exactly one atom left
       else if((vec_end-vec_first)==1){
-        return AtomTree(&list_of_atoms[vec_first],NULL,NULL);
+        return new AtomTree(&list_of_atoms[vec_first],NULL,NULL);
       }
 
       else{
         sort(list_of_atoms, vec_first, vec_end, dim);
         int median = (vec_end-vec_first)/2; // operation rounds down
-        return AtomTree(
+        return new AtomTree(
             &list_of_atoms[median], 
             buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
             buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
       }
     }
   private:
-    AtomTree left_child = NULL;
-    AtomTree right_child = NULL;
+    AtomTree* left_child = NULL;
+    AtomTree* right_child = NULL;
     
     void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
       // TODO  

--- a/atomtree.h
+++ b/atomtree.h
@@ -6,19 +6,18 @@
 #include <vector>
 #include <cmath> 
 
-struct Atom;
 class AtomTree{
   public:
-    AtomTree(Atom* at, AtomTree* left_node, AtomTree* right_node) 
+    AtomTree(Atom* at, AtomTree left_node, AtomTree right_node) 
       : atom(at), left_child(left_node), right_child(right_node) {}
     
     Atom* atom = NULL;
     
     //TODO add exception for empty node
-    AtomTree* getLeftChild(){
+    AtomTree getLeftChild(){
       return left_child;
     }
-    AtomTree* getRightChild(){
+    AtomTree getRightChild(){
       return right_child;
     }
     
@@ -26,7 +25,7 @@ class AtomTree{
     // rather than copying the list of atoms in every recursion, or saving the partitioned
     // vectors, the original list of atoms is passed by reference and only the vector limits
     // are passed by value. any sorting during the tree building occurs in the original list
-    AtomTree* buildTree(
+    AtomTree buildTree(
         std::vector<Atom>& list_of_atoms, 
         int vec_first, // index of first vector element (default 0)
         int vec_end, // vector size (index of last element + 1)
@@ -37,21 +36,21 @@ class AtomTree{
       }
       // if list of atoms has exactly one atom left
       else if((vec_end-vec_first)==1){
-        return new AtomTree(&list_of_atoms[vec_first],NULL,NULL);
+        return AtomTree(&list_of_atoms[vec_first],NULL,NULL);
       }
 
       else{
         sort(list_of_atoms, vec_first, vec_end, dim);
         int median = (vec_end-vec_first)/2; // operation rounds down
-        return new AtomTree(
+        return AtomTree(
             &list_of_atoms[median], 
             buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
             buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
       }
     }
   private:
-    AtomTree* left_child = NULL;
-    AtomTree* right_child = NULL;
+    AtomTree left_child = NULL;
+    AtomTree right_child = NULL;
     
     void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
       // TODO  

--- a/atomtree.h
+++ b/atomtree.h
@@ -10,6 +10,7 @@ struct AtomNode{
   AtomNode(Atom* at, AtomNode* left_node, AtomNode* right_node); 
     
   Atom* atom; // using pointer so that original atom list can be kept and objects do not have to be copied
+  // using pointers, so that children can be assigned to null pointers
   AtomNode* left_child;
   AtomNode* right_child;
 
@@ -22,12 +23,16 @@ class AtomTree{
   public:
     AtomTree();
     AtomTree(std::vector<Atom>& list_of_atoms);
+    
+    const AtomNode* getRoot() const;
 
+    const double getMaxRad() const;
     void print() const;
 
   private:
     AtomNode* root;
-    
+    double max_rad;
+
     AtomNode* buildTree(
         std::vector<Atom>& list_of_atoms, 
         int vec_first, // index of first vector element (default 0)

--- a/atomtree.h
+++ b/atomtree.h
@@ -23,7 +23,7 @@ class AtomTree{
     AtomTree();
     AtomTree(std::vector<Atom>& list_of_atoms);
 
-    void print();
+    void print() const;
 
   private:
     AtomNode* root;
@@ -34,7 +34,8 @@ class AtomTree{
         int vec_end, // vector size (index of last element + 1)
         char dim);
   
-    void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim);
+    void quicksort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim);
+    void swap(Atom& a, Atom& b);
 };
 
 

--- a/atomtree.h
+++ b/atomtree.h
@@ -1,62 +1,40 @@
-#ifndef ATOM_H
+#ifndef ATOMTREE_H
 
-#define ATOM_H
+#define ATOMTREE_H
 
-#include "atom.h"
 #include <vector>
-#include <cmath> 
 
 struct Atom;
+class AtomTree;
+struct AtomNode{
+  AtomNode(Atom* at, AtomNode* left_node, AtomNode* right_node); 
+    
+  Atom* atom; // using pointer so that original atom list can be kept and objects do not have to be copied
+  AtomNode* left_child;
+  AtomNode* right_child;
+
+  void print();
+};
+
+struct Atom;
+struct AtomNode;
 class AtomTree{
   public:
-    AtomTree(Atom* at, AtomTree* left_node, AtomTree* right_node) 
-      : atom(at), left_child(left_node), right_child(right_node) {}
+    AtomTree();
+    AtomTree(std::vector<Atom>& list_of_atoms);
+
+    void print();
+
+  private:
+    AtomNode* root;
     
-    Atom* atom = NULL;
-    
-    //TODO add exception for empty node
-    AtomTree* getLeftChild(){
-      return left_child;
-    }
-    AtomTree* getRightChild(){
-      return right_child;
-    }
-    
-    // recursive function to generate a 3-d tree from a list of atoms
-    // rather than copying the list of atoms in every recursion, or saving the partitioned
-    // vectors, the original list of atoms is passed by reference and only the vector limits
-    // are passed by value. any sorting during the tree building occurs in the original list
-    AtomTree* buildTree(
+    AtomNode* buildTree(
         std::vector<Atom>& list_of_atoms, 
         int vec_first, // index of first vector element (default 0)
         int vec_end, // vector size (index of last element + 1)
-        char dim){
-      // if list of atoms has no atoms left
-      if((vec_end-vec_first)==0){
-        return NULL;
-      }
-      // if list of atoms has exactly one atom left
-      else if((vec_end-vec_first)==1){
-        return new AtomTree(&list_of_atoms[vec_first],NULL,NULL);
-      }
-
-      else{
-        sort(list_of_atoms, vec_first, vec_end, dim);
-        int median = (vec_end-vec_first)/2; // operation rounds down
-        return new AtomTree(
-            &list_of_atoms[median], 
-            buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
-            buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
-      }
-    }
-  private:
-    AtomTree* left_child = NULL;
-    AtomTree* right_child = NULL;
-    
-    void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
-      // TODO  
-      return;
-    }
+        char dim);
+  
+    void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim);
 };
 
 

--- a/atomtree.h
+++ b/atomtree.h
@@ -1,0 +1,63 @@
+#ifndef ATOM_H
+
+#define ATOM_H
+
+#include "atom.h"
+#include <vector>
+#include <cmath> 
+
+struct Atom;
+class AtomTree{
+  public:
+    AtomTree(Atom* at, AtomTree* left_node, AtomTree* right_node) 
+      : atom(at), left_child(left_node), right_child(right_node) {}
+    
+    Atom* atom = NULL;
+    
+    //TODO add exception for empty node
+    AtomTree* getLeftChild(){
+      return left_child;
+    }
+    AtomTree* getRightChild(){
+      return right_child;
+    }
+    
+    // recursive function to generate a 3-d tree from a list of atoms
+    // rather than copying the list of atoms in every recursion, or saving the partitioned
+    // vectors, the original list of atoms is passed by reference and only the vector limits
+    // are passed by value. any sorting during the tree building occurs in the original list
+    AtomTree* buildTree(
+        std::vector<Atom>& list_of_atoms, 
+        int vec_first, // index of first vector element (default 0)
+        int vec_end, // vector size (index of last element + 1)
+        char dim){
+      // if list of atoms has no atoms left
+      if((vec_end-vec_first)==0){
+        return NULL;
+      }
+      // if list of atoms has exactly one atom left
+      else if((vec_end-vec_first)==1){
+        return new AtomTree(&list_of_atoms[vec_first],NULL,NULL);
+      }
+
+      else{
+        sort(list_of_atoms, vec_first, vec_end, dim);
+        int median = (vec_end-vec_first)/2; // operation rounds down
+        return new AtomTree(
+            &list_of_atoms[median], 
+            buildTree(list_of_atoms, vec_first, median, (dim%3)+1), 
+            buildTree(list_of_atoms, median+1, vec_end, (dim%3)+1)); 
+      }
+    }
+  private:
+    AtomTree* left_child = NULL;
+    AtomTree* right_child = NULL;
+    
+    void sort(std::vector<Atom>& list_of_atoms, const int& vec_first, const int& vec_end, const char& dim){
+      // TODO  
+      return;
+    }
+};
+
+
+#endif

--- a/base.h
+++ b/base.h
@@ -16,6 +16,7 @@ class MainApp: public wxApp
 class MainFrame: public wxFrame
 {
   public:
+
     // methods for controller communication
     void clearOutput();
     void printToOutput(std::string& text);
@@ -24,10 +25,14 @@ class MainFrame: public wxFrame
     std::string getRadiusFilepath();
     double getGridsize();
     int getDepth();
+    double getProbeRadius();
 
     MainFrame(const wxString &title, const wxPoint &pos, const wxSize &size);
     
   private:
+    
+    double r_probe = 1.5; //* hard coded for testing purposes. eventually obtain from user input
+
       wxPanel* browsePanel;
         wxPanel* atomfilePanel;
           wxButton* browseButton;

--- a/base_guicontrol.cpp
+++ b/base_guicontrol.cpp
@@ -39,3 +39,7 @@ int MainFrame::getDepth(){
   return depthInput->GetValue();
 }
 
+//* get from user input
+double MainFrame::getProbeRadius(){
+  return r_probe;
+}

--- a/controller.cpp
+++ b/controller.cpp
@@ -41,7 +41,7 @@ bool Ctrl::runCalculation(){
   // read atoms from file and save a vector containing the atoms
   current_calculation->readRadiiFromFile(radius_filepath);
   current_calculation->readAtomsFromFile(atom_filepath);
-  current_calculation->storeAtomsInTree();
+  current_calculation->storeAtomsInTree(); // TODO consider moving this to readAtomsFromFile method in model class
   
   // get user inputs
   const double grid_step = gui->getGridsize();

--- a/controller.cpp
+++ b/controller.cpp
@@ -41,6 +41,7 @@ bool Ctrl::runCalculation(){
   // read atoms from file and save a vector containing the atoms
   current_calculation->readRadiiFromFile(radius_filepath);
   current_calculation->readAtomsFromFile(atom_filepath);
+  current_calculation->storeAtomsInTree();
   
   // get user inputs
   const double grid_step = gui->getGridsize();

--- a/controller.cpp
+++ b/controller.cpp
@@ -4,6 +4,7 @@
 #include "atom.h" // i don't know why
 #include "model.h"
 #include <vector>
+#include <chrono>
 
 ///////////////////////
 // STATIC ATTRIBUTES //
@@ -27,10 +28,6 @@ Ctrl* Ctrl::getInstance(){
   return instance;
 }
     
-bool Ctrl::runCalculation(std::string& atom_filepath){ //* std::string& radius_filepath
-  return false;
-}
-
 bool Ctrl::runCalculation(){ 
   
   // create an instance of the model class
@@ -45,12 +42,20 @@ bool Ctrl::runCalculation(){
   current_calculation->readRadiiFromFile(radius_filepath);
   current_calculation->readAtomsFromFile(atom_filepath);
   
+  // get user inputs
   const double grid_step = gui->getGridsize();
   const int max_depth = gui->getDepth();
-  // set space size (size of unit cell/ box containing all atoms)
+  const double r_probe = gui->getProbeRadius();
+  // set space size (size of box containing all atoms)
   current_calculation->defineCell(grid_step, max_depth);
-  
+  current_calculation->findCloseAtoms(r_probe);
+
+  auto start = std::chrono::steady_clock::now();
   current_calculation->calcVolume();
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<double> elapsed_seconds = end-start;
+  
+  Ctrl::notifyUser("Elapsed time: " + std::to_string(elapsed_seconds.count()));
   
   return true;
 }

--- a/controller.h
+++ b/controller.h
@@ -9,7 +9,6 @@ class Model;
 class MainFrame;
 class Ctrl{
   public:
-    bool runCalculation(std::string& filepath); //* remove
     bool runCalculation();
     void registerView(MainFrame* inp_gui);
     static Ctrl* getInstance();

--- a/exception.h
+++ b/exception.h
@@ -1,0 +1,16 @@
+#ifndef EXCEPTION_H
+
+#define EXCEPTION_H
+
+#include <iostream>
+#include <exception>
+
+struct ExceptIllegalFunctionCall : public std::exception
+{
+	const char * what () const throw () {
+    	return "Ex: Illegal Function Call. Argument not allowed";
+    }
+};
+
+
+#endif

--- a/misc.h
+++ b/misc.h
@@ -9,4 +9,8 @@ inline double distance(const std::array<double,3> &start, const std::array<doubl
   return std::pow( (pow(end[0]-start[0],2) + pow(end[1]-start[1],2) + pow(end[2]-start[2],2)) , 0.5);
 }
 
+inline double distance(const std::array<double,3> &start, const std::array<double,3> &end, const int dim){
+  return end[dim]-start[dim];
+}
+
 #endif

--- a/model.cpp
+++ b/model.cpp
@@ -12,7 +12,6 @@ void Model::defineCell(const double& grid_step, const int& max_depth){
 
 void Model::storeAtomsInTree(){
   atomtree = AtomTree(atoms);
-  atomtree.print();
 }
 
 void Model::findCloseAtoms(const double& r_probe){

--- a/model.cpp
+++ b/model.cpp
@@ -3,13 +3,17 @@
 #include "space.h"
 #include "controller.h"
 #include "atom.h"
-#include "atomtree.h"
 #include <array>
 #include <string>
 
 void Model::defineCell(const double& grid_step, const int& max_depth){
   cell = new Space(atoms, grid_step, max_depth);
   return;
+}
+
+void Model::storeAtomsInTree(){
+  atomtree = AtomTree(atoms);
+  atomtree.print();
 }
 
 void Model::findCloseAtoms(const double& r_probe){

--- a/model.cpp
+++ b/model.cpp
@@ -1,13 +1,12 @@
 
 #include "model.h"
-#include "space.h"
 #include "controller.h"
 #include "atom.h"
 #include <array>
 #include <string>
 
 void Model::defineCell(const double& grid_step, const int& max_depth){
-  cell = new Space(atoms, grid_step, max_depth);
+  cell = Space(atoms, grid_step, max_depth);
   return;
 }
 
@@ -22,15 +21,15 @@ void Model::findCloseAtoms(const double& r_probe){
 }
 
 void Model::calcVolume(){
-  cell->placeAtomsInGrid(atoms);
-  double volume = cell->getVolume();
+  cell.placeAtomsInGrid(atoms);
+  double volume = cell.getVolume();
   Ctrl::getInstance()->notifyUser("Van der Waals Volume: " + std::to_string(volume));
   return;
 }
 
 void Model::debug(){
-  std::array<double,3> cell_min = cell->getMin();
-  std::array<double,3> cell_max = cell->getMax();
+  std::array<double,3> cell_min = cell.getMin();
+  std::array<double,3> cell_max = cell.getMax();
 
   for(int dim = 0; dim < 3; dim++){
     std::cout << "Cell Limit in Dim " << dim << ":" << cell_min[dim] << " and " << cell_max[dim] << std::endl; 

--- a/model.cpp
+++ b/model.cpp
@@ -2,6 +2,8 @@
 #include "model.h"
 #include "space.h"
 #include "controller.h"
+#include "atom.h"
+#include "atomtree.h"
 #include <array>
 #include <string>
 
@@ -10,9 +12,13 @@ void Model::defineCell(const double& grid_step, const int& max_depth){
   return;
 }
 
+void Model::findCloseAtoms(const double& r_probe){
+  //TODO  
+  return;
+}
+
 void Model::calcVolume(){
   cell->placeAtomsInGrid(atoms);
-
   double volume = cell->getVolume();
   Ctrl::getInstance()->notifyUser("Van der Waals Volume: " + std::to_string(volume));
   return;

--- a/model.cpp
+++ b/model.cpp
@@ -21,7 +21,7 @@ void Model::findCloseAtoms(const double& r_probe){
 }
 
 void Model::calcVolume(){
-  cell.placeAtomsInGrid(atoms);
+  cell.placeAtomsInGrid(atoms, atomtree);
   double volume = cell.getVolume();
   Ctrl::getInstance()->notifyUser("Van der Waals Volume: " + std::to_string(volume));
   return;

--- a/model.h
+++ b/model.h
@@ -3,10 +3,12 @@
 #define MODEL_H
 
 // class for dealing with program logic
+#include "atomtree.h"
 #include <iostream>
 #include <vector>
 #include <unordered_map>
 
+class AtomTree;
 struct Atom;
 class Space;
 class Model{
@@ -17,11 +19,13 @@ class Model{
     void readAtomsFromFile(std::string&);
     // calls the Space constructor and creates a cell containing all atoms. Cell size is defined by atom positions
     void defineCell(const double&, const int&);
+    void storeAtomsInTree();
     void findCloseAtoms(const double&); //TODO
     void calcVolume();
     void debug();
   private:
     std::vector<Atom> atoms;
+    AtomTree atomtree;
     Space* cell;
     std::unordered_map<std::string,double> radii;
 };

--- a/model.h
+++ b/model.h
@@ -13,10 +13,11 @@ class Model{
   public:
     void readRadiiFromFile(std::string&);
     inline double findRadiusOfAtom(const std::string&);
-    inline double findRadiusOfAtom(const Atom&); //* has not been tested
+    inline double findRadiusOfAtom(const Atom&); //TODO has not been tested
     void readAtomsFromFile(std::string&);
     // calls the Space constructor and creates a cell containing all atoms. Cell size is defined by atom positions
     void defineCell(const double&, const int&);
+    void findCloseAtoms(const double&); //TODO
     void calcVolume();
     void debug();
   private:

--- a/model.h
+++ b/model.h
@@ -4,6 +4,7 @@
 
 // class for dealing with program logic
 #include "atomtree.h"
+#include "space.h"
 #include <iostream>
 #include <vector>
 #include <unordered_map>
@@ -26,7 +27,7 @@ class Model{
   private:
     std::vector<Atom> atoms;
     AtomTree atomtree;
-    Space* cell;
+    Space cell; 
     std::unordered_map<std::string,double> radii;
 };
 

--- a/model_filereading.cpp
+++ b/model_filereading.cpp
@@ -77,7 +77,8 @@ void Model::readAtomsFromFile(std::string& filepath){
     
     else { // subsequent lines contain atom positional data
       std::vector<std::string> substrings = splitLine(line);
-
+      for(std::string str : substrings){
+      }
       // create new atom and add to storage vector (assumes file format: Element_Symbol x y z)
       Atom at = Atom(std::stod(substrings[1]), 
                      std::stod(substrings[2]), 
@@ -93,7 +94,6 @@ void Model::readAtomsFromFile(std::string& filepath){
   // check if number of atoms matches size of the vector containing the atoms
   assert(n_atom == list_of_atoms.size());
   this->atoms = list_of_atoms;
-  
   return;
 }
 

--- a/model_filereading.cpp
+++ b/model_filereading.cpp
@@ -20,10 +20,10 @@ static inline std::vector<std::string> splitLine(std::string& line){
 // the Model object
 void Model::readRadiiFromFile(std::string& filepath){
  
-  //* add case handling for when file has already been read
-  //* if map empty: ask user via dialog boy if they want to
-  //* reimport the file
-  //* make a function "consultUser(string)"
+  //TODO add case handling for when file has already been read
+  //TODO if map empty: ask user via dialog boy if they want to
+  //TODO reimport the file
+  //TODO make a function "consultUser(string)"
   //if(radii.empty()){std::cout << "empty" << std::endl;}
 
   std::string line;
@@ -40,7 +40,7 @@ void Model::readRadiiFromFile(std::string& filepath){
 
 // returns the radius of an atom with a given symbol
 inline double Model::findRadiusOfAtom(const std::string& symbol){
-  //* add exception handling for when no radius was found:
+  //TODO add exception handling for when no radius was found:
   //if(radii[symbol == 0]){
   //  throw ...;
   //}
@@ -55,14 +55,14 @@ inline double Model::findRadiusOfAtom(const Atom& at){
 void Model::readAtomsFromFile(std::string& filepath){
 
   int n_atom;
-  std::vector<Atom> list_of_atoms; // will contain the atoms
+  std::vector<Atom> list_of_atoms;
 
-//if (inp_file.is_open()){  //* consider adding an exception, for when file in not valid
+//if (inp_file.is_open()){  //TODO consider adding an exception, for when file in not valid
 
   // we iterate through the lines in the input file
   std::string line;
   std::ifstream inp_file(filepath);
-  // init counter to keep track of line number
+
   int line_counter = 0;
   // iterate through lines
   while(getline(inp_file,line)){

--- a/space.cpp
+++ b/space.cpp
@@ -10,7 +10,7 @@
 // VOLUME COMP //
 /////////////////
 
-void Space::placeAtomsInGrid(const std::vector<Atom> &atoms, const AtomTree& atomtree){
+void Space::placeAtomsInGrid(const std::vector<Atom> &atoms, const AtomTree& atomtree){ // TODO: remove atoms argument. no longer necessary
   // calculate position of first voxel
   std::array<double,3> vxl_origin = getOrigin();
   
@@ -28,7 +28,7 @@ void Space::placeAtomsInGrid(const std::vector<Atom> &atoms, const AtomTree& ato
         Voxel& vxl = getElement(x,y,z);
         std::array<double,3> vxl_pos = 
           {vxl_origin[0] + vxl_dist * x, vxl_origin[1] + vxl_dist * y, vxl_origin[2] + vxl_dist * z};
-        vxl.determineType(atoms, vxl_pos, grid_size, max_depth, atomtree);
+        vxl.determineType(vxl_pos, grid_size, max_depth, atomtree);
       }
     }
   }      

--- a/space.cpp
+++ b/space.cpp
@@ -2,6 +2,7 @@
 #include "space.h"
 #include "atom.h"
 #include "voxel.h"
+#include "atomtree.h"
 #include <cmath>
 #include <cassert>
 
@@ -9,7 +10,7 @@
 // VOLUME COMP //
 /////////////////
 
-void Space::placeAtomsInGrid(const std::vector<Atom> &atoms){
+void Space::placeAtomsInGrid(const std::vector<Atom> &atoms, const AtomTree& atomtree){
   // calculate position of first voxel
   std::array<double,3> vxl_origin = getOrigin();
   
@@ -27,7 +28,7 @@ void Space::placeAtomsInGrid(const std::vector<Atom> &atoms){
         Voxel& vxl = getElement(x,y,z);
         std::array<double,3> vxl_pos = 
           {vxl_origin[0] + vxl_dist * x, vxl_origin[1] + vxl_dist * y, vxl_origin[2] + vxl_dist * z};
-        vxl.determineType(atoms, vxl_pos, grid_size, max_depth);
+        vxl.determineType(atoms, vxl_pos, grid_size, max_depth, atomtree);
       }
     }
   }      

--- a/space.h
+++ b/space.h
@@ -10,6 +10,7 @@ struct Atom;
 class Voxel;
 class Space{
   public:
+    Space() = default;
     Space(std::vector<Atom>&, const double&, const int&);
     std::array <double,3> getMin();
     std::array <double,3> getOrigin(); // same as getMin();

--- a/space.h
+++ b/space.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <array>
 
+class AtomTree;
 struct Atom;
 class Voxel;
 class Space{
@@ -21,7 +22,7 @@ class Space{
     Voxel& getElement(const size_t &i);
     void printGrid();
 
-    void placeAtomsInGrid(const std::vector<Atom>&);
+    void placeAtomsInGrid(const std::vector<Atom>&, const AtomTree&);
     double getVolume();
   
   private:

--- a/voxel.cpp
+++ b/voxel.cpp
@@ -3,8 +3,16 @@
 #include "misc.h"
 #include "atom.h"
 #include "atomtree.h"
-#include <cmath>
+#include <cmath> // abs, pow
 #include <cassert>
+
+///////////////////
+// AUX FUNCTIONS //
+///////////////////
+
+inline double calcSphereOfInfluence(const double& grid_size, const double& max_depth){
+  return pow(3,0.5)*(grid_size * pow(2,max_depth))/2; // TODO: avoid expensive pow function
+}
 
 /////////////////
 // CONSTRUCTOR //
@@ -37,17 +45,124 @@ char Voxel::getType(){
 //////////////
 
 void Voxel::determineType
-  (const std::vector<Atom>& atoms, 
-   std::array<double,3> pos, // voxel centre
+   (std::array<double,3> vxl_pos, // voxel centre
    const double& grid_size,
    const double max_depth,
    const AtomTree& atomtree)
 {
-  determineType(atoms,pos,grid_size,max_depth);
+  double at_rad = atomtree.getMaxRad();
+  double vxl_rad = calcSphereOfInfluence(grid_size, max_depth);
+    
+  traverseTree(atomtree.getRoot(), 0, at_rad, vxl_rad, vxl_pos, grid_size, max_depth); 
+
+  if(type == 'm'){
+    // TODO define method for this part Voxel::splitVoxel()
+    // split into 8 subvoxels
+    for(int i = 0; i < 8; i++){
+      data.push_back(Voxel());
+      // modify position
+      std::array<int,3> factors = {
+        ((i%2) >= 1 )? 1 : -1,
+        ((i%4) >= 2 )? 1 : -1,
+        ( i    >= 4 )? 1 : -1};
+     
+      std::array<double,3> new_pos;
+      for(int dim = 0; dim < 3; dim++){
+        new_pos[dim] = vxl_pos[dim] + factors[dim] * grid_size * std::pow(2,max_depth-2);
+      }
+      data[i].determineType(new_pos, grid_size, max_depth-1, atomtree);
+    }
+  }
   return;
 }
 
+// use the properties of the binary tree to recursively traverse the tree and 
+// only check the voxel type with respect to relevant atoms. at the end of this 
+// method, the type of the voxel will have been set.
+void Voxel::traverseTree
+  (const AtomNode* node, 
+   int dim, const double& at_rad, 
+   const double& vxl_rad, 
+   const std::array<double,3> vxl_pos, 
+   const double& grid_size, 
+   const double& max_depth){
+  if (node == NULL){
+    return;
+  }
+  
+  std::array<double,3> at_pos = node->atom->getPos();
+  double dist1D = distance(at_pos, vxl_pos, dim);
 
+  // check if voxel is close enough to atom
+  if (abs(dist1D) > (vxl_rad + at_rad)){ // if not continue to next child
+    if (dist1D < 0){
+      traverseTree(node->left_child, (dim+1)%3, at_rad, vxl_rad, vxl_pos, grid_size, max_depth);
+    }
+    else{
+      traverseTree(node->right_child, (dim+1)%3, at_rad, vxl_rad, vxl_pos, grid_size, max_depth);
+    }
+  }
+  else{ // if voxel is close enough, check distance to the node's atom. if needed, 
+        // continue with both children
+    determineTypeSingleAtom(*(node->atom), vxl_pos, grid_size, max_depth);
+    if (type != 'a'){
+      traverseTree(node->left_child, (dim+1)%3, at_rad, vxl_rad, vxl_pos, grid_size, max_depth);
+    }
+    if (type != 'a'){
+      traverseTree(node->right_child, (dim+1)%3, at_rad, vxl_rad, vxl_pos, grid_size, max_depth);
+    }
+  }
+  return;
+}
+
+void Voxel::determineTypeSingleAtom
+  (const Atom& atom, 
+   std::array<double,3> vxl_pos, // voxel centre
+   const double& grid_size,
+   const double max_depth)
+{
+  // only mixed and empty type voxels need to be considered
+  if(type == 'a'){
+    return;
+  }
+  if(max_depth == 0){ // for bottom level voxels
+
+    // check if centre is inside atom
+    double dist_vxl_at = distance(vxl_pos, atom.getPos());
+    if (atom.rad > dist_vxl_at){// voxel centre is inside atom radius
+      type = 'a';
+      return;
+    }
+    // else type remains unchanged, i.e., empty 
+  }
+  else{ // for higher level voxels
+    
+    // determine the radius of the sphere that contains the voxel
+    // the voxels side length is given by the grid_size (i.e. the side length
+    // of a bottom level voxel) multiplied with 2^max_depth. This value multiplied
+    // with the sqrt of 3 gives the diagonal of the voxel. The radius is half the
+    // diagonal.
+    double radius_of_influence = pow(3,0.5)*(grid_size * pow(2,max_depth))/2; // TODO: avoid expensive pow function
+
+    double dist_vxl_at = distance(vxl_pos, atom.getPos());
+    
+    // is voxel inside atom? 
+    if(atom.rad > (dist_vxl_at + radius_of_influence)){ 
+      type = 'a'; // in atom
+      return;
+    }
+    // is voxel partially inside atom?
+    else if(atom.rad > (dist_vxl_at - radius_of_influence)){
+      type = 'm'; // mixed
+      return;
+    }
+    // else type remains unchanged
+  }
+  return;
+}
+
+/*
+No longer needed, since determineType using atomtree is much faster
 // iterates through all top level voxels and determines their type in
 // relation to the input atoms. when a voxel of mixed type is encountered
 // eight subvoxels are created. this is continued until the maximum tree
@@ -78,7 +193,7 @@ void Voxel::determineType
     // of a bottom level voxel) multiplied with 2^max_depth. This value multiplied
     // with the sqrt of 3 gives the diagonal of the voxel. The radius is half the
     // diagonal.
-    double radius_of_influence = pow(3,0.5)*(grid_size * pow(2,max_depth))/2;
+    double radius_of_influence = pow(3,0.5)*(grid_size * pow(2,max_depth))/2; // TODO: avoid expensive pow function
     
     for(auto const& atom : atoms){
       
@@ -117,6 +232,7 @@ void Voxel::determineType
   }
   return;
 }
+*/
 
 ///////////
 // TALLY //

--- a/voxel.cpp
+++ b/voxel.cpp
@@ -5,6 +5,14 @@
 #include <cmath>
 #include <cassert>
 
+/////////////////
+// CONSTRUCTOR //
+/////////////////
+
+Voxel::Voxel(){
+  type = 'e';
+}
+
 ////////////
 // ACCESS //
 ////////////
@@ -27,21 +35,23 @@ char Voxel::getType(){
 // SET TYPE //
 //////////////
 
+// iterates through all top level voxels and determines their type in
+// relation to the input atoms. when a voxel of mixed type is encountered
+// eight subvoxels are created. this is continued until the maximum tree
+// depth is reached
 void Voxel::determineType
   (const std::vector<Atom>& atoms, 
-   std::array<double,3> pos,
+   std::array<double,3> pos, // voxel centre
    const double& grid_size,
    const double max_depth)
 {
-
-  type = 'e'; // default type empty
   if(max_depth == 0){ // for bottom level voxels
 
     for(int at = 0; at < atoms.size(); at++){ // check against all atoms
       // check if centre is inside atom
       Atom atom = atoms[at];
-      double dist = distance(pos, atom.getPos());
-      if (atom.rad > dist){// voxel centre is inside atom radius
+      double dist_vxl_at = distance(pos, atom.getPos());
+      if (atom.rad > dist_vxl_at){// voxel centre is inside atom radius
         type = 'a';
         return;
       }
@@ -49,22 +59,25 @@ void Voxel::determineType
     }
   }
   else{ // for higher level voxels
+    
     // determine the radius of the sphere that contains the voxel
     // the voxels side length is given by the grid_size (i.e. the side length
     // of a bottom level voxel) multiplied with 2^max_depth. This value multiplied
     // with the sqrt of 3 gives the diagonal of the voxel. The radius is half the
     // diagonal.
     double radius_of_influence = pow(3,0.5)*(grid_size * pow(2,max_depth))/2;
-
-    for(int at = 0; at < atoms.size(); at++){ // check against all atoms
-      Atom atom = atoms[at];
-      double dist = distance(pos, atom.getPos()); // distance betwee voxel centre and atom centre
-       
-      if(atom.rad > (dist + radius_of_influence)){ // voxel is entirely inside atom
+    
+    for(auto const& atom : atoms){
+      
+      double dist_vxl_at = distance(pos, atom.getPos());
+     
+      // is voxel inside atom? 
+      if(atom.rad > (dist_vxl_at + radius_of_influence)){ 
         type = 'a'; // in atom
         return;
       }
-      else if(atom.rad > (dist - radius_of_influence)){ // atom border cuts through voxel
+      // is voxel partially inside atom?
+      else if(atom.rad > (dist_vxl_at - radius_of_influence)){
         type = 'm'; // mixed
       }
       //else empty

--- a/voxel.cpp
+++ b/voxel.cpp
@@ -2,6 +2,7 @@
 #include "voxel.h"
 #include "misc.h"
 #include "atom.h"
+#include "atomtree.h"
 #include <cmath>
 #include <cassert>
 
@@ -34,6 +35,18 @@ char Voxel::getType(){
 //////////////
 // SET TYPE //
 //////////////
+
+void Voxel::determineType
+  (const std::vector<Atom>& atoms, 
+   std::array<double,3> pos, // voxel centre
+   const double& grid_size,
+   const double max_depth,
+   const AtomTree& atomtree)
+{
+  determineType(atoms,pos,grid_size,max_depth);
+  return;
+}
+
 
 // iterates through all top level voxels and determines their type in
 // relation to the input atoms. when a voxel of mixed type is encountered

--- a/voxel.h
+++ b/voxel.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+class AtomTree;
 struct Atom;
 class Voxel{
   public:
@@ -17,6 +18,12 @@ class Voxel{
        std::array<double,3> pos,
        const double& grid_size,
        const double max_depth);
+    void determineType
+      (const std::vector<Atom>& atoms, 
+       std::array<double,3> pos,
+       const double& grid_size,
+       const double max_depth,
+       const AtomTree& atomtree);
     size_t tallyVoxelsOfType(const char volume_type, const int max_depth);
 
   private:

--- a/voxel.h
+++ b/voxel.h
@@ -7,6 +7,7 @@
 struct Atom;
 class Voxel{
   public:
+    Voxel();
     Voxel& access(const short& x, const short& y, const short& z);
     Voxel& access(const short& i);
     char getType();

--- a/voxel.h
+++ b/voxel.h
@@ -6,24 +6,42 @@
 
 class AtomTree;
 struct Atom;
+struct AtomNode;
 class Voxel{
   public:
     Voxel();
     Voxel& access(const short& x, const short& y, const short& z);
     Voxel& access(const short& i);
     char getType();
-    
+
+   /* replaced by other determineType function
     void determineType
       (const std::vector<Atom>& atoms, 
        std::array<double,3> pos,
        const double& grid_size,
        const double max_depth);
+    */
+
     void determineType
-      (const std::vector<Atom>& atoms, 
-       std::array<double,3> pos,
+       (std::array<double,3> pos,
        const double& grid_size,
        const double max_depth,
        const AtomTree& atomtree);
+    
+    void determineTypeSingleAtom
+      (const Atom& atom, 
+       std::array<double,3> pos, // voxel centre
+       const double& grid_size,
+       const double max_depth);
+   
+    void traverseTree
+      (const AtomNode* node, 
+       int dim, 
+       const double& at_rad, 
+       const double& vxl_rad, 
+       const std::array<double,3> vxl_pos,
+       const double& grid_size, 
+       const double& max_depth);
     size_t tallyVoxelsOfType(const char volume_type, const int max_depth);
 
   private:


### PR DESCRIPTION
This change massively improves performance by using a binary tree, rather than a list of atoms, to determine the type of individual voxels. As such, voxels do no longer need to loop through all atoms but can ignore many that are too far away. The average complexity is reduced from O(m*n), where m is the number of voxels and n is the number of atoms, to O(m*log(n)).