### PR TITLE
Fix issue #16, evaluate input coordinate correctly

### DIFF
--- a/model_filereading.cpp
+++ b/model_filereading.cpp
@@ -110,7 +110,11 @@ bool isAtomLine(const std::vector<std::string>& substrings) {
   for (char i=1; i<4; i++){
     // using a try-block feels hacky, but the alternative using strtod does as well
     try {
-      std::stod(substrings[i]);
+      size_t str_pos = 0; // will contain the last position in the string that was successfully evaluated by std::stod()
+      std::stod(substrings[i], &str_pos);
+      if (substrings[i].size() != str_pos) {
+        return false;
+      }
     }
     catch (const std::invalid_argument& ia) {
       return false;


### PR DESCRIPTION
The isAtomLine() function in Model class has been reworked. With this
new change, only lines in the input file will be considered, in which
the x-, y-, and z-coordinates are purely numerical. Previously, a
coordinate such as "3x15" would have been valid, and interpreted as "3".
This is no longer the case.

Resolves: #16 