### PR TITLE
Add initial colors in atom list grid and move fileExtension function

### DIFF
--- a/include/misc.h
+++ b/include/misc.h
@@ -2,6 +2,7 @@
 
 #define MISC_H
 
+#include <string>
 #include <array>
 #include <cmath>
 
@@ -13,16 +14,6 @@ inline double distance(const std::array<double,3> &start, const std::array<doubl
   return end[dim]-start[dim];
 }
 
-inline std::string fileExtension(const std::string& path){
-  // will cause an issue, if there is a dot in the middle of the file AND no file extension
-  std::string after_dot = "";
-  int dot_pos = path.find_last_of(".");
-  if (dot_pos != std::string::npos){
-    return path.substr(dot_pos+1);
-  }
-  else{
-    return "invalid";
-  }
-}
+std::string fileExtension(const std::string& path);
 
 #endif

--- a/include/misc.h
+++ b/include/misc.h
@@ -13,4 +13,16 @@ inline double distance(const std::array<double,3> &start, const std::array<doubl
   return end[dim]-start[dim];
 }
 
+inline std::string fileExtension(const std::string& path){
+  // will cause an issue, if there is a dot in the middle of the file AND no file extension
+  std::string after_dot = "";
+  int dot_pos = path.find_last_of(".");
+  if (dot_pos != std::string::npos){
+    return path.substr(dot_pos+1);
+  }
+  else{
+    return "invalid";
+  }
+}
+
 #endif

--- a/src/base_event.cpp
+++ b/src/base_event.cpp
@@ -6,6 +6,7 @@
 
 #include "base.h"
 #include "controller.h"
+#include "misc.h"
 #include <vector>
 
 /////////////////
@@ -69,12 +70,12 @@ void MainFrame::enableGuiElements(bool inp){
     calcButton->Enable(false);
   }
   // activates pdb specific options only if pdb file is loaded
-    if (getAtomFilepath().size() > 3 && getAtomFilepath().substr(getAtomFilepath().size()-4, 4) == ".pdb"){
-      pdbHetatmCheckbox->Enable(true);
-    }
-    else {
-      pdbHetatmCheckbox->Enable(false);
-    }
+  if (fileExtension(getAtomFilepath()) == "pdb"){
+    pdbHetatmCheckbox->Enable(true);
+  }
+  else {
+    pdbHetatmCheckbox->Enable(false);
+  }
 }
 
 // browse for atom file

--- a/src/base_guicontrol.cpp
+++ b/src/base_guicontrol.cpp
@@ -53,14 +53,11 @@ void MainFrame::displayAtomList(std::vector<std::tuple<std::string, int, double>
   // delete all rows
   // DeleteRows causes an error if there are no rows
   if (atomListGrid->GetNumberRows() > 0) {
-//    atomListGrid->ClearGrid(); // seems unneccessary
     atomListGrid->DeleteRows(0, atomListGrid->GetNumberRows());
   }
 
   for (int row = 0; row < symbol_number_radius.size(); row++) {
     atomListGrid->AppendRows(1, true);
-    // column 0 (include checkbox)
-    atomListGrid->SetCellValue(row,0,"1");
     // column 1 (symbol of atom)
     atomListGrid->SetCellValue(row, 1, std::get<0>(symbol_number_radius[row]));
     atomListGrid->SetReadOnly(row,1,true);
@@ -69,6 +66,20 @@ void MainFrame::displayAtomList(std::vector<std::tuple<std::string, int, double>
     atomListGrid->SetReadOnly(row,2,true);
     // column 3 (radius of atom)
     atomListGrid->SetCellValue(row, 3, std::to_string(std::get<2>(symbol_number_radius[row])));
+    // column 0 (include checkbox)
+    // if no radius is found for the element, color cells to point it to the user
+    // TODO: need to see if the colors can be automatically handled in base_event
+    if (std::wcstod(atomListGrid->GetCellValue(row, 3), NULL) == 0){
+      atomListGrid->SetCellBackgroundColour(row, 1, col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row, 2, col_grey_cell);
+      atomListGrid->SetCellBackgroundColour(row, 3, col_red_cell);
+    }
+    else { // if a radius is found, include by default the element
+      atomListGrid->SetCellValue(row, 0, "1");
+    }
+    // refresh the grid to enforce the update of cell values and parameters
+    // without this, it was sometimes observed that the last cell was not updated properly
+    atomListGrid->Refresh();
   }
 }
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,0 +1,14 @@
+#include "misc.h"
+
+std::string fileExtension(const std::string& path){
+  // will cause an issue, if there is a dot in the middle of the file AND no file extension
+  std::string after_dot = "";
+  int dot_pos = path.find_last_of(".");
+  if (dot_pos != std::string::npos){
+    return path.substr(dot_pos+1);
+  }
+  else{
+    return "invalid";
+  }
+}
+

--- a/src/model_filereading.cpp
+++ b/src/model_filereading.cpp
@@ -1,6 +1,7 @@
 #include "model.h"
 #include "atom.h"
 #include "controller.h"
+#include "misc.h"
 #include <string>
 #include <vector>
 #include <iostream>
@@ -18,7 +19,6 @@
 bool isAtomLine(const std::vector<std::string>& substrings);
 std::string strToValidSymbol(std::string str);
 static inline std::vector<std::string> splitLine(std::string& line);
-std::string fileExtension(const std::string& path);
 
 /////////////////
 // FILE IMPORT //
@@ -157,18 +157,6 @@ inline double Model::findRadiusOfAtom(const Atom& at){
 ///////////////////
 // AUX FUNCTIONS //
 ///////////////////
-
-std::string fileExtension(const std::string& path){
-  // will cause an issue, if there is a dot in the middle of the file AND no file extension
-  std::string after_dot = "";
-  int dot_pos = path.find_last_of(".");
-  if (dot_pos != std::string::npos){
-    return path.substr(dot_pos+1);
-  }
-  else{
-    return "invalid";
-  }
-}
 
 // split line into substrings when separated by whitespaces
 static inline std::vector<std::string> splitLine(std::string& line){


### PR DESCRIPTION
Since we don't have currently a working way to handle dynamically atom list grid colors based on their value, their color is set when the grid rows are created.
Need to find an alternative to handle dynamically or, at least, to update the colors efficiently when elements are included/excluded.

Following comment from merge 37, the fileExtension() auxiliary function was moved from model_filereading.cpp to misc.h to be accessible globally.