### PR TITLE
Remove white background in text controls

### DIFF
--- a/src/base_init.cpp
+++ b/src/base_init.cpp
@@ -208,8 +208,6 @@ void MainFrame::InitAtomfilePanel(){
 								wxDefaultSize,
 								0,
 								wxDefaultValidator);
-	//for dark mode
-	filepathText->SetBackgroundColour(col_white);
 
   SetSizerFilePanel(atomfilePanel, browseButton, filepathText);
 }
@@ -221,8 +219,6 @@ void MainFrame::InitRadiusfilePanel(){
   radiuspathText = new wxTextCtrl(radiusfilePanel,
 								  TEXT_Radius,
 								  "./inputfile/radii.txt");
-	//for dark mode
-	radiuspathText->SetBackgroundColour(col_white);
 
   SetSizerFilePanel(radiusfilePanel, radiusButton, radiuspathText);
 }
@@ -310,7 +306,6 @@ void MainFrame::InitGridPanel(){
 void MainFrame::InitGridinputPanel(){
 
   gridsizeInputText = new wxTextCtrl(gridsizeInputPanel, TEXT_Gridinput, "0.1");
-  gridsizeInputText->SetBackgroundColour(col_white);
 
   gridsizeUnitText = new wxStaticText(gridsizeInputPanel, TEXT_Gridunit, L"\u212B "); // unicode for angstrom
 
@@ -328,7 +323,6 @@ void MainFrame::InitDepthPanel(){
 
   depthInput = new wxSpinCtrl
     (depthPanel, SPIN_Depthinput, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 20, 4);
-  depthInput->SetBackgroundColour(col_white);
 
   wxBoxSizer *depthSizer = new wxBoxSizer(wxHORIZONTAL);
   depthSizer->Add(depthText,0,wxALIGN_CENTRE_VERTICAL | wxALL,10);


### PR DESCRIPTION
Now the text control background colour is determined by the system colours on macOS. The app is usable in dark mode again.